### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/lib/extras/core/path.dart
+++ b/lib/extras/core/path.dart
@@ -462,7 +462,7 @@ class Path extends CurvePath {
 
       if (action == PathAction.MOVE_TO) {
 
-        if (lastPath.actions.length != 0) {
+        if (lastPath.actions.isNotEmpty) {
 
           subPaths.add(lastPath);
           lastPath = new Path();
@@ -475,7 +475,7 @@ class Path extends CurvePath {
 
     }
 
-    if (lastPath.actions.length != 0) {
+    if (lastPath.actions.isNotEmpty) {
 
       subPaths.add(lastPath);
 

--- a/lib/src/objects/mesh.dart
+++ b/lib/src/objects/mesh.dart
@@ -37,7 +37,7 @@ class Mesh extends Object3D {
 
 
       // setup morph targets
-      if (geometry.morphTargets.length != 0) {
+      if (geometry.morphTargets.isNotEmpty) {
         morphTargetBase = -1;
         morphTargetForcedOrder = [];
         morphTargetInfluences = [];


### PR DESCRIPTION
Use isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)